### PR TITLE
[FEAT] add auth signup post

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/core": "^8.0.0",
         "@nestjs/platform-express": "^8.0.0",
         "@nestjs/typeorm": "^8.0.3",
+        "bcryptjs": "^2.4.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.13.2",
         "pg": "^8.7.3",
@@ -2668,6 +2669,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -11296,6 +11302,11 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
     },
     "binary-extensions": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@nestjs/core": "^8.0.0",
     "@nestjs/platform-express": "^8.0.0",
     "@nestjs/typeorm": "^8.0.3",
+    "bcryptjs": "^2.4.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
     "pg": "^8.7.3",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,8 +2,9 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { BoardsModule } from './boards/boards.module';
 import { typeORMConfig } from './configs/typeorm.config';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forRoot(typeORMConfig), BoardsModule],
+  imports: [TypeOrmModule.forRoot(typeORMConfig), BoardsModule, AuthModule],
 })
 export class AppModule {}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,15 @@
+import { Body, Controller, Post, ValidationPipe } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { AuthCredentialDto } from './dto/auth-credential.dto';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private authService: AuthService) {}
+
+  @Post('/signup')
+  signUp(
+    @Body(ValidationPipe) authCredentialDto: AuthCredentialDto,
+  ): Promise<void> {
+    return this.authService.signUp(authCredentialDto);
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { UserRepository } from './user.repository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([UserRepository])],
+  controllers: [AuthController],
+  providers: [AuthService],
+})
+export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { AuthCredentialDto } from './dto/auth-credential.dto';
+import { UserRepository } from './user.repository';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    @InjectRepository(UserRepository)
+    private userRepository: UserRepository,
+  ) {}
+
+  async signUp(authCredentialDto: AuthCredentialDto): Promise<void> {
+    return this.userRepository.createUser(authCredentialDto);
+  }
+}

--- a/src/auth/dto/auth-credential.dto.ts
+++ b/src/auth/dto/auth-credential.dto.ts
@@ -1,0 +1,17 @@
+import { IsString, Matches, MaxLength, MinLength } from 'class-validator';
+
+export class AuthCredentialDto {
+  @IsString()
+  @MinLength(4)
+  @MaxLength(20)
+  username: string;
+
+  @IsString()
+  @MinLength(4)
+  @MaxLength(20)
+  //영어랑 숫자만 가능한 유효성 체크
+  @Matches(/^[a-zA-Z0-9]*$/, {
+    message: 'password only accepts english and number',
+  })
+  password: string;
+}

--- a/src/auth/user.entity.ts
+++ b/src/auth/user.entity.ts
@@ -1,0 +1,23 @@
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+
+@Entity()
+@Unique(['username'])
+export class User extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  username: string;
+
+  @Column()
+  password: string;
+
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: string;
+}

--- a/src/auth/user.repository.ts
+++ b/src/auth/user.repository.ts
@@ -1,0 +1,30 @@
+import {
+  ConflictException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { EntityRepository, Repository } from 'typeorm';
+import { AuthCredentialDto } from './dto/auth-credential.dto';
+import { User } from './user.entity';
+import * as bcrypt from 'bcryptjs';
+
+@EntityRepository(User)
+export class UserRepository extends Repository<User> {
+  async createUser(authCredentialDto: AuthCredentialDto): Promise<void> {
+    const { username, password } = authCredentialDto;
+
+    // 비밀번호 암호화
+    const salt = await bcrypt.genSalt();
+    const hashedPassword = await bcrypt.hash(password, salt);
+    const user = this.create({ username, password: hashedPassword });
+
+    try {
+      await this.save(user);
+    } catch (error) {
+      if (error.code === '23505') {
+        throw new ConflictException('Existing username');
+      } else {
+        throw new InternalServerErrorException();
+      }
+    }
+  }
+}

--- a/src/boards/board.entity.ts
+++ b/src/boards/board.entity.ts
@@ -14,4 +14,7 @@ export class Board extends BaseEntity {
 
   @Column()
   status: BoardStatus;
+
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: string;
 }


### PR DESCRIPTION
- class-validator를 이용한 request 유효성 검사 (validation pipe)
- username unique하도록 예외 처리
- bcrypt와 salt를 이용한 비밀번호 암호화
- board 테이블에 created_at 컬럼 추가